### PR TITLE
fix(oauth): avoid shell execution for OAuth URLs

### DIFF
--- a/typescript/packages/mcpfy/src/auth/node-oauth-provider.ts
+++ b/typescript/packages/mcpfy/src/auth/node-oauth-provider.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { spawn } from "node:child_process";
+import { execFile } from "node:child_process";
 import { createServer, type Server } from "node:http";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -69,9 +69,7 @@ function openUrl(url: string): void {
   console.log(`\nOpen this URL to authorize:\n  ${url}\n`);
   const command = process.platform === "darwin" ? "open" : process.platform === "win32" ? "rundll32.exe" : "xdg-open";
   const args = process.platform === "win32" ? ["url.dll,FileProtocolHandler", url] : [url];
-  const child = spawn(command, args, { detached: true, stdio: "ignore", shell: false });
-  child.once("error", () => {});
-  child.unref();
+  execFile(command, args, () => {});
 }
 
 /**

--- a/typescript/packages/mcpfy/src/auth/node-oauth-provider.ts
+++ b/typescript/packages/mcpfy/src/auth/node-oauth-provider.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { exec } from "node:child_process";
+import { spawn } from "node:child_process";
 import { createServer, type Server } from "node:http";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -67,8 +67,11 @@ async function scanForFreePort([start, end]: [number, number]): Promise<number> 
 /** Prints the URL (the reliable fallback) and best-effort tries to open the OS browser too. */
 function openUrl(url: string): void {
   console.log(`\nOpen this URL to authorize:\n  ${url}\n`);
-  const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-  exec(`${cmd} "${url}"`, () => {});
+  const command = process.platform === "darwin" ? "open" : process.platform === "win32" ? "rundll32.exe" : "xdg-open";
+  const args = process.platform === "win32" ? ["url.dll,FileProtocolHandler", url] : [url];
+  const child = spawn(command, args, { detached: true, stdio: "ignore", shell: false });
+  child.once("error", () => {});
+  child.unref();
 }
 
 /**

--- a/typescript/packages/mcpfy/tests/client-oauth-provider.test.ts
+++ b/typescript/packages/mcpfy/tests/client-oauth-provider.test.ts
@@ -1,14 +1,27 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NodeOAuthClientProvider } from "../src/auth/node-oauth-provider.js";
+
+const { spawnMock, childOnceMock, childUnrefMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  childOnceMock: vi.fn(),
+  childUnrefMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock.mockReturnValue({ once: childOnceMock, unref: childUnrefMock }),
+}));
 
 describe("NodeOAuthClientProvider", () => {
   let dataDir: string;
 
   beforeEach(() => {
     dataDir = mkdtempSync(join(tmpdir(), "mcpfy-oauth-test-"));
+    spawnMock.mockClear();
+    childOnceMock.mockClear();
+    childUnrefMock.mockClear();
   });
 
   afterEach(() => {
@@ -42,6 +55,24 @@ describe("NodeOAuthClientProvider", () => {
     const first = await NodeOAuthClientProvider.create({ serverUrl: "https://mcp.example.com", dataDir });
     const second = await NodeOAuthClientProvider.create({ serverUrl: "https://mcp.example.com", dataDir });
     expect(second.redirectUrl).toBe(first.redirectUrl);
+  });
+
+  it("opens authorization URLs as literal process arguments without a shell", async () => {
+    const provider = await NodeOAuthClientProvider.create({ serverUrl: "https://mcp.example.com", dataDir });
+    const authorizationUrl = new URL("https://fake-auth.example.com/authorize?value=$(touch%20/tmp/pwned)");
+
+    await provider.redirectToAuthorization(authorizationUrl);
+    const codePromise = provider.getAuthorizationCode();
+    await fetch(`${provider.redirectUrl}?code=real-auth-code`);
+    await codePromise;
+
+    expect(spawnMock).toHaveBeenCalledOnce();
+    const [command, args, options] = spawnMock.mock.calls[0];
+    expect(command).not.toContain(authorizationUrl.toString());
+    expect(args).toContain(authorizationUrl.toString());
+    expect(options).toMatchObject({ shell: false });
+    expect(childOnceMock).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(childUnrefMock).toHaveBeenCalledOnce();
   });
 
   it("resolves getAuthorizationCode() when the loopback server receives a real callback request", async () => {

--- a/typescript/packages/mcpfy/tests/client-oauth-provider.test.ts
+++ b/typescript/packages/mcpfy/tests/client-oauth-provider.test.ts
@@ -4,14 +4,10 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NodeOAuthClientProvider } from "../src/auth/node-oauth-provider.js";
 
-const { spawnMock, childOnceMock, childUnrefMock } = vi.hoisted(() => ({
-  spawnMock: vi.fn(),
-  childOnceMock: vi.fn(),
-  childUnrefMock: vi.fn(),
-}));
+const execFileMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", () => ({
-  spawn: spawnMock.mockReturnValue({ once: childOnceMock, unref: childUnrefMock }),
+  execFile: execFileMock,
 }));
 
 describe("NodeOAuthClientProvider", () => {
@@ -19,9 +15,7 @@ describe("NodeOAuthClientProvider", () => {
 
   beforeEach(() => {
     dataDir = mkdtempSync(join(tmpdir(), "mcpfy-oauth-test-"));
-    spawnMock.mockClear();
-    childOnceMock.mockClear();
-    childUnrefMock.mockClear();
+    execFileMock.mockClear();
   });
 
   afterEach(() => {
@@ -57,34 +51,18 @@ describe("NodeOAuthClientProvider", () => {
     expect(second.redirectUrl).toBe(first.redirectUrl);
   });
 
-  it("opens authorization URLs as literal process arguments without a shell", async () => {
+  it("opens authorization URLs without a shell and resolves the loopback callback", async () => {
     const provider = await NodeOAuthClientProvider.create({ serverUrl: "https://mcp.example.com", dataDir });
     const authorizationUrl = new URL("https://fake-auth.example.com/authorize?value=$(touch%20/tmp/pwned)");
 
     await provider.redirectToAuthorization(authorizationUrl);
-    const codePromise = provider.getAuthorizationCode();
-    await fetch(`${provider.redirectUrl}?code=real-auth-code`);
-    await codePromise;
-
-    expect(spawnMock).toHaveBeenCalledOnce();
-    const [command, args, options] = spawnMock.mock.calls[0];
-    expect(command).not.toContain(authorizationUrl.toString());
-    expect(args).toContain(authorizationUrl.toString());
-    expect(options).toMatchObject({ shell: false });
-    expect(childOnceMock).toHaveBeenCalledWith("error", expect.any(Function));
-    expect(childUnrefMock).toHaveBeenCalledOnce();
-  });
-
-  it("resolves getAuthorizationCode() when the loopback server receives a real callback request", async () => {
-    const provider = await NodeOAuthClientProvider.create({ serverUrl: "https://mcp.example.com", dataDir });
-
-    await provider.redirectToAuthorization(new URL("https://fake-auth.example.com/authorize?client_id=abc"));
     const codePromise = provider.getAuthorizationCode();
 
     const callbackRes = await fetch(`${provider.redirectUrl}?code=real-auth-code&state=xyz`);
     expect(callbackRes.status).toBe(200);
 
     await expect(codePromise).resolves.toBe("real-auth-code");
+    expect(execFileMock.mock.calls[0][1]).toContain(authorizationUrl.toString());
   });
 
   it("rejects getAuthorizationCode() when the callback reports an error", async () => {


### PR DESCRIPTION
OAuth authorization URLs come from remote metadata. Passing them through a shell could execute embedded shell syntax. Use execFile() with argument arrays so URLs remain literal values.