### PR TITLE
fix(transport): recover from auth verifier errors

### DIFF
--- a/typescript/packages/mcpfy/src/server/transport.ts
+++ b/typescript/packages/mcpfy/src/server/transport.ts
@@ -119,8 +119,8 @@ export async function startHttp(
     if (options.auth) {
       const auth = options.auth;
       queue = queue.then(async () => {
-        const result = await checkAuth(req, auth);
-        if (!result.ok) {
+        const result = await checkAuth(req, auth).catch(() => undefined);
+        if (!result?.ok) {
           writeUnauthorized(res, auth, req, listenState);
           return;
         }

--- a/typescript/packages/mcpfy/tests/server-auth-header.test.ts
+++ b/typescript/packages/mcpfy/tests/server-auth-header.test.ts
@@ -12,11 +12,17 @@ describe("header auth", () => {
     server = undefined;
   });
 
-  it("rejects requests without a token, rejects wrong tokens, accepts the right one", async () => {
+  it("rejects missing auth, recovers from verifier errors, and accepts valid auth", async () => {
     server = new MCPServer({
       name: "auth-fixture",
       version: "1.0.0",
-      auth: { type: "header", verify: (token) => token === "correct-token" },
+      auth: {
+        type: "header",
+        verify: (token) => {
+          if (token === "wrong-token") throw new Error("Verifier failed");
+          return token === "correct-token";
+        },
+      },
     });
     server.tool(
       { name: "whoami", schema: z.object({}), outputSchema: z.object({ authenticated: z.boolean() }) },


### PR DESCRIPTION
Auth verifier errors rejected the serialized HTTP queue, causing subsequent requests to hang. Treat verifier errors as unauthorized so the queue remains usable.