### PR TITLE
fix(transport): validate HTTP origin and host headers

### DIFF
--- a/typescript/packages/mcpfy/src/server/http-security.ts
+++ b/typescript/packages/mcpfy/src/server/http-security.ts
@@ -1,0 +1,43 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+const LOOPBACK_HOSTS = ["localhost", "127.0.0.1", "[::1]"];
+
+export interface HttpSecurityOptions {
+  port: number;
+  host: string;
+  allowedHosts?: string[];
+  allowedOrigins?: string[];
+}
+
+export function deriveBaseUrl(req: IncomingMessage, options: Pick<HttpSecurityOptions, "port" | "host">): string {
+  const forwardedProto = (req.headers["x-forwarded-proto"] as string | undefined)?.split(",")[0];
+  const proto = forwardedProto === "https" ? "https" : "http";
+  return `${proto}://${req.headers.host ?? `${options.host}:${options.port}`}`;
+}
+
+export function validateRequestHeaders(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: HttpSecurityOptions
+): boolean {
+  const isLoopback = ["localhost", "127.0.0.1", "::1", "[::1]"].includes(options.host.toLowerCase());
+  const allowedHosts =
+    options.allowedHosts ?? (isLoopback ? LOOPBACK_HOSTS.flatMap((host) => [host, `${host}:${options.port}`]) : []);
+  const allowedOrigins =
+    options.allowedOrigins ??
+    (isLoopback ? LOOPBACK_HOSTS.flatMap((host) => [`http://${host}`, `http://${host}:${options.port}`]) : []);
+  const includes = (values: string[], value?: string) =>
+    value !== undefined && values.some((allowed) => allowed.toLowerCase() === value.toLowerCase());
+  const origin = req.headers.origin;
+
+  if (
+    (allowedHosts.length > 0 && !includes(allowedHosts, req.headers.host)) ||
+    (allowedOrigins.length > 0 && origin !== undefined && !includes(allowedOrigins, origin))
+  ) {
+    res.writeHead(403, { "content-type": "application/json" }).end(
+      JSON.stringify({ jsonrpc: "2.0", error: { code: -32000, message: "Forbidden" }, id: null })
+    );
+    return false;
+  }
+  return true;
+}

--- a/typescript/packages/mcpfy/src/server/mcp-server.ts
+++ b/typescript/packages/mcpfy/src/server/mcp-server.ts
@@ -31,6 +31,10 @@ export interface ListenOptions {
   port?: number;
   /** HTTP only. Defaults to "localhost". */
   host?: string;
+  /** HTTP only. Exact allowed Host headers. Loopback listeners allow loopback hosts by default; pass `[]` to disable. */
+  allowedHosts?: string[];
+  /** HTTP only. Exact allowed browser Origins. Loopback listeners allow loopback origins by default; pass `[]` to disable. */
+  allowedOrigins?: string[];
   /** HTTP only. Suppress the startup log line with the local URL. Defaults to false. */
   silent?: boolean;
 }
@@ -153,6 +157,8 @@ export class MCPServer {
       port,
       host,
       auth: this.config.auth,
+      allowedHosts: options.allowedHosts,
+      allowedOrigins: options.allowedOrigins,
       silent: options.silent,
     });
 

--- a/typescript/packages/mcpfy/src/server/transport.ts
+++ b/typescript/packages/mcpfy/src/server/transport.ts
@@ -30,7 +30,8 @@ function formatListenUrl(host: string, port: number): string {
 }
 
 function deriveBaseUrl(req: IncomingMessage, options: { port: number; host: string }): string {
-  const proto = (req.headers["x-forwarded-proto"] as string | undefined)?.split(",")[0] ?? "http";
+  const forwardedProto = (req.headers["x-forwarded-proto"] as string | undefined)?.split(",")[0];
+  const proto = forwardedProto === "https" ? "https" : "http";
   const host = req.headers.host ?? `${options.host}:${options.port}`;
   return `${proto}://${host}`;
 }
@@ -46,9 +47,37 @@ function writeUnauthorized(res: ServerResponse, auth: AuthConfig, req: IncomingM
     .end(JSON.stringify({ jsonrpc: "2.0", error: { code: -32001, message: "Unauthorized" }, id: null }));
 }
 
+const LOOPBACK_HOSTS = ["localhost", "127.0.0.1", "[::1]"];
+
+function validateRequestHeaders(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: { port: number; host: string; allowedHosts?: string[]; allowedOrigins?: string[] }
+): boolean {
+  const isLoopback = ["localhost", "127.0.0.1", "::1", "[::1]"].includes(options.host.toLowerCase());
+  const allowedHosts =
+    options.allowedHosts ?? (isLoopback ? LOOPBACK_HOSTS.flatMap((host) => [host, `${host}:${options.port}`]) : []);
+  const allowedOrigins =
+    options.allowedOrigins ??
+    (isLoopback ? LOOPBACK_HOSTS.flatMap((host) => [`http://${host}`, `http://${host}:${options.port}`]) : []);
+  const includes = (values: string[], value?: string) =>
+    value !== undefined && values.some((allowed) => allowed.toLowerCase() === value.toLowerCase());
+  const origin = req.headers.origin;
+  if (
+    (allowedHosts.length > 0 && !includes(allowedHosts, req.headers.host)) ||
+    (allowedOrigins.length > 0 && origin !== undefined && !includes(allowedOrigins, origin))
+  ) {
+    res.writeHead(403, { "content-type": "application/json" }).end(
+      JSON.stringify({ jsonrpc: "2.0", error: { code: -32000, message: "Forbidden" }, id: null })
+    );
+    return false;
+  }
+  return true;
+}
+
 export async function startHttp(
   nativeServer: OfficialMcpServer,
-  options: { port: number; host: string; auth?: AuthConfig; silent?: boolean }
+  options: { port: number; host: string; auth?: AuthConfig; allowedHosts?: string[]; allowedOrigins?: string[]; silent?: boolean }
 ): Promise<HttpHandle> {
   const { StreamableHTTPServerTransport } = await import("@modelcontextprotocol/sdk/server/streamableHttp.js");
   const http = await import("node:http");
@@ -93,6 +122,8 @@ export async function startHttp(
   }
 
   const httpServer = http.createServer((req: IncomingMessage, res: ServerResponse) => {
+    if (!validateRequestHeaders(req, res, { ...options, ...listenState })) return;
+
     if (options.auth?.type === "oauth" && req.method === "GET" && req.url === "/.well-known/oauth-protected-resource") {
       const baseUrl = deriveBaseUrl(req, listenState);
       res

--- a/typescript/packages/mcpfy/src/server/transport.ts
+++ b/typescript/packages/mcpfy/src/server/transport.ts
@@ -5,6 +5,7 @@ import { checkAuth } from "./auth/middleware.js";
 import { buildProtectedResourceMetadata } from "./auth/well-known.js";
 import type { AuthConfig } from "./auth/types.js";
 import { setRequestAuth, setRequestHeaders, extractForwardableAuthHeaders } from "./context.js";
+import { deriveBaseUrl, validateRequestHeaders, type HttpSecurityOptions } from "./http-security.js";
 
 export interface HttpHandle {
   /** Bound TCP port (resolved after listen — useful when you passed `port: 0`). */
@@ -29,13 +30,6 @@ function formatListenUrl(host: string, port: number): string {
   return `http://${hostPart}:${port}/mcp`;
 }
 
-function deriveBaseUrl(req: IncomingMessage, options: { port: number; host: string }): string {
-  const forwardedProto = (req.headers["x-forwarded-proto"] as string | undefined)?.split(",")[0];
-  const proto = forwardedProto === "https" ? "https" : "http";
-  const host = req.headers.host ?? `${options.host}:${options.port}`;
-  return `${proto}://${host}`;
-}
-
 function writeUnauthorized(res: ServerResponse, auth: AuthConfig, req: IncomingMessage, options: { port: number; host: string }): void {
   const headers: Record<string, string> = { "content-type": "application/json" };
   if (auth.type === "oauth") {
@@ -47,37 +41,9 @@ function writeUnauthorized(res: ServerResponse, auth: AuthConfig, req: IncomingM
     .end(JSON.stringify({ jsonrpc: "2.0", error: { code: -32001, message: "Unauthorized" }, id: null }));
 }
 
-const LOOPBACK_HOSTS = ["localhost", "127.0.0.1", "[::1]"];
-
-function validateRequestHeaders(
-  req: IncomingMessage,
-  res: ServerResponse,
-  options: { port: number; host: string; allowedHosts?: string[]; allowedOrigins?: string[] }
-): boolean {
-  const isLoopback = ["localhost", "127.0.0.1", "::1", "[::1]"].includes(options.host.toLowerCase());
-  const allowedHosts =
-    options.allowedHosts ?? (isLoopback ? LOOPBACK_HOSTS.flatMap((host) => [host, `${host}:${options.port}`]) : []);
-  const allowedOrigins =
-    options.allowedOrigins ??
-    (isLoopback ? LOOPBACK_HOSTS.flatMap((host) => [`http://${host}`, `http://${host}:${options.port}`]) : []);
-  const includes = (values: string[], value?: string) =>
-    value !== undefined && values.some((allowed) => allowed.toLowerCase() === value.toLowerCase());
-  const origin = req.headers.origin;
-  if (
-    (allowedHosts.length > 0 && !includes(allowedHosts, req.headers.host)) ||
-    (allowedOrigins.length > 0 && origin !== undefined && !includes(allowedOrigins, origin))
-  ) {
-    res.writeHead(403, { "content-type": "application/json" }).end(
-      JSON.stringify({ jsonrpc: "2.0", error: { code: -32000, message: "Forbidden" }, id: null })
-    );
-    return false;
-  }
-  return true;
-}
-
 export async function startHttp(
   nativeServer: OfficialMcpServer,
-  options: { port: number; host: string; auth?: AuthConfig; allowedHosts?: string[]; allowedOrigins?: string[]; silent?: boolean }
+  options: HttpSecurityOptions & { auth?: AuthConfig; silent?: boolean }
 ): Promise<HttpHandle> {
   const { StreamableHTTPServerTransport } = await import("@modelcontextprotocol/sdk/server/streamableHttp.js");
   const http = await import("node:http");

--- a/typescript/packages/mcpfy/tests/http-roundtrip.test.ts
+++ b/typescript/packages/mcpfy/tests/http-roundtrip.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { request } from "node:http";
 import { z } from "zod";
 import { MCPServer } from "../src/server/mcp-server.js";
 import { MCPClient } from "../src/client/mcp-client.js";
@@ -26,6 +27,19 @@ describe("http transport end-to-end", () => {
     const info = await server.listen({ transport: "http", port: 0, silent: true });
     expect(info.url).toMatch(/^http:\/\/localhost:\d+\/mcp$/);
     expect(info.port).toBeGreaterThan(0);
+
+    const rpcBody = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+    const statusFor = (headers: Record<string, string>) =>
+      new Promise<number>((resolve, reject) => {
+        const req = request(info.url!, { method: "POST", headers }, (res) => {
+          res.resume();
+          resolve(res.statusCode ?? 0);
+        });
+        req.on("error", reject).end(rpcBody);
+      });
+    for (const headers of [{ host: "attacker.example" }, { origin: "https://attacker.example" }]) {
+      expect(await statusFor({ "content-type": "application/json", ...headers })).toBe(403);
+    }
 
     client = new MCPClient({ mcpServers: { fixture: { url: info.url! } } });
     const session = await client.createSession("fixture");

--- a/typescript/packages/mcpfy/tests/server-auth-oauth.test.ts
+++ b/typescript/packages/mcpfy/tests/server-auth-oauth.test.ts
@@ -33,7 +33,7 @@ describe("oauth auth", () => {
 
     const noAuth = await fetch(`${base}/mcp`, {
       method: "POST",
-      headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+      headers: { "content-type": "application/json", accept: "application/json, text/event-stream", "x-forwarded-proto": "javascript" },
       body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
     });
     expect(noAuth.status).toBe(401);


### PR DESCRIPTION
Local HTTP servers accepted arbitrary Host and Origin headers, enabling DNS-rebinding access from malicious websites. Validate loopback requests by default, support explicit allowlists for hosted deployments, and restrict forwarded protocols to HTTP or HTTPS.