### PR TITLE
docs: correct CONTRIBUTING scope, document repo layout, add community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Something in mcpfy doesn't behave the way it documents.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For questions about the MCP protocol itself rather than mcpfy, the
+        [MCP spec](https://modelcontextprotocol.io) and the
+        [official SDK](https://github.com/modelcontextprotocol/typescript-sdk) are the
+        source of truth — mcpfy is a thin wrapper around them.
+
+  - type: dropdown
+    id: package
+    attributes:
+      label: Package
+      options:
+        - mcpfy-sdk
+        - create-mcpfy-app
+        - mcpfy-pulse
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      placeholder: "0.2.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Transport
+      options:
+        - stdio
+        - http
+        - Both
+        - Not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What you expected, and what you got instead. Include the full error if there is one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: >
+        The smallest server or client that shows the problem. A repo link is ideal; an inline
+        snippet is fine. This is usually the difference between a same-day fix and a stalled issue.
+      render: typescript
+    validations:
+      required: true
+
+  - type: input
+    id: node
+    attributes:
+      label: Node.js version
+      description: "Output of `node -v`. mcpfy supports 20.19+ and 22.12+."
+      placeholder: "v22.12.0"
+    validations:
+      required: true
+
+  - type: input
+    id: client
+    attributes:
+      label: MCP client
+      description: Which client you connected with, if relevant.
+      placeholder: "Claude Code, Claude Desktop, Cursor, custom..."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: MCP protocol question
+    url: https://modelcontextprotocol.io
+    about: For questions about the Model Context Protocol itself rather than mcpfy.
+  - name: Official MCP TypeScript SDK
+    url: https://github.com/modelcontextprotocol/typescript-sdk
+    about: mcpfy wraps this SDK — behavior inherited from it belongs there.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest something mcpfy should be able to do.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Check [ROADMAP.md](../blob/main/ROADMAP.md) first — it may already be planned.
+
+        mcpfy is deliberately small and stays close to the official SDK. Proposals that keep
+        the API surface flat, rather than adding a new abstraction, are much likelier to land.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you running into?
+      description: Describe the situation, not the solution. What are you trying to build?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like mcpfy to do?
+      description: If you have an API shape in mind, sketch it.
+      render: typescript
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What have you tried instead?
+      description: >
+        Including whether you can already do this by dropping down to `server.nativeServer`,
+        the escape hatch to the official SDK.
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      options:
+        - label: I'd be willing to open a PR for this

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+## What this changes
+
+<!-- What the PR does, and why. If it fixes an issue, add "Fixes #123". -->
+
+## Why
+
+<!-- The problem being solved. For anything beyond a small fix, link the issue where the
+     scope was discussed. -->
+
+## How it was verified
+
+<!-- What you actually ran, and what it printed. Not just "tests pass". -->
+
+```
+cd typescript
+pnpm build
+pnpm test
+```
+
+## Checklist
+
+- [ ] `pnpm build` and `pnpm test` pass from `typescript/`
+- [ ] Tests exercise real behavior (a real server/client round trip), not mocked internals
+- [ ] The relevant package README is updated if the public API changed
+- [ ] `examples/hello-world` is updated if this changes how a basic server is written
+- [ ] Breaking changes to public APIs are called out below
+
+## Breaking changes
+
+<!-- None, or describe them and the migration path. -->
+
+## Telemetry
+
+<!-- Only if you touched mcpfy-pulse. mcpfy-pulse promises it never transmits argument values
+     or resource content. If you changed what goes into a TelemetryEvent, say what the new
+     field carries and link the test proving it can't carry user data. -->
+
+N/A

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,110 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance, race, caste,
+color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning
+  from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their
+  explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable
+behavior and will take appropriate and fair corrective action in response to any behavior that
+they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of
+Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces — issues, pull requests, discussions,
+and code review — and also applies when an individual is officially representing the community
+in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+maintainers of this repository. All complaints will be reviewed and investigated promptly and
+fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any
+incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences
+for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or
+unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the
+nature of the violation and an explanation of why the behavior was inappropriate. A public
+apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the
+people involved for a specified period of time. Violating these terms may lead to a temporary
+or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained
+inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the
+community for a specified period of time. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including
+sustained inappropriate behavior, harassment of an individual, or aggression toward or
+disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,57 +1,100 @@
 # Contributing to mcpfy
 
-Thanks for considering a contribution. mcpfy is intentionally small — please keep that in mind
-when proposing changes: prefer the minimal fix over a new abstraction, and prefer opening an
-issue to discuss scope before large PRs, especially anything that would pull mcpfy toward
-mcpfy's larger feature set (Apps/widgets, OAuth, telemetry, etc.) — those are deliberately out
-of scope for now.
+Thanks for considering a contribution. mcpfy is a thin, deliberately small wrapper around the
+official [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk) —
+not a reimplementation of it. Please keep that in mind when proposing changes: prefer the
+minimal fix over a new abstraction, and prefer opening an issue to discuss scope before a large
+PR, especially anything that adds public API surface.
 
 ## Getting set up
 
+Requires **Node.js 20.19+** (or 22.12+) and **pnpm 10+**.
+
 ```bash
-git clone <this-repo>
+git clone https://github.com/mcpfyy/mcpfy.git
 cd mcpfy/typescript
 pnpm install
 pnpm build
 pnpm test
 ```
 
-Requires Node.js 20.19+ (or 22.12+) and pnpm 10+.
+All four commands should succeed on a fresh clone. If they don't, that's a bug worth an issue.
+
+> `pnpm build` and `pnpm test` run recursively over `packages/*` in dependency order.
+> `mcpfy-sdk` imports `mcpfy-pulse`, so building a single package in isolation can fail on
+> unresolved workspace imports — build from `typescript/` instead.
 
 ## Project layout
 
-See the root [README.md](./README.md#repository-structure) for the repo layout, and
-[`typescript/README.md`](./typescript/README.md) for TypeScript-specific development commands.
+See [Repository structure](./README.md#repository-structure) in the root README for the full
+layout, and [`typescript/README.md`](./typescript/README.md) for TypeScript-specific commands.
+
+Short version — three published packages under `typescript/packages/`:
+
+- **`mcpfy`** (npm `mcpfy-sdk`) — the SDK: tools, prompts, resources, widgets, transports, auth.
+- **`create-mcpfy-app`** — the scaffolder behind `npx create-mcpfy-app`.
+- **`mcpfy-pulse`** — opt-in telemetry.
+
+## Running things locally
+
+```bash
+# Per-package builds and tests
+pnpm --filter mcpfy-sdk build
+pnpm --filter mcpfy-sdk test
+pnpm --filter mcpfy-sdk test:watch
+pnpm --filter mcpfy-pulse test
+
+# Run the scaffolder from source, without publishing or installing
+pnpm --filter create-mcpfy-app dev -- my-test-app --no-install
+
+# Run an example server against your local build
+pnpm --filter @mcpfy-examples/hello-world start:stdio
+pnpm --filter @mcpfy-examples/hello-world start:http
+```
 
 ## Making changes
 
 1. **Open an issue first** for anything beyond a small fix — especially new public API surface.
-2. **Write tests that exercise real behavior.** This project's convention is: spin up an actual
-   `MCPServer` and connect a real `MCPClient` to it, and assert on the round trip. See
-   `typescript/packages/mcpfy/tests/` for examples. Don't mock the SDK internals — if you're
-   mocking everything, the test isn't proving anything.
+2. **Write tests that exercise real behavior.** The convention here is to spin up an actual
+   `MCPServer`, connect a real `MCPClient` to it, and assert on the round trip. See
+   `typescript/packages/mcpfy/tests/` for the pattern, including two true end-to-end tests: one
+   spawns a real stdio child process (`stdio-roundtrip.test.ts`), the other runs a real HTTP
+   server (`http-roundtrip.test.ts`). `mcpfy-pulse`'s tests follow the same idea, standing up a
+   real HTTP server as the telemetry endpoint and asserting on the bytes that actually arrive.
+   Don't mock the SDK internals — if you're mocking everything, the test isn't proving anything.
 3. **Keep the diff minimal.** Don't refactor unrelated code alongside a feature or fix.
 4. **Breaking changes to public APIs** need to be called out explicitly in the PR description —
    don't silently add backwards-compatibility shims without discussion.
 
+### Telemetry changes need extra care
+
+`mcpfy-pulse` promises it never transmits argument values or resource content — only method
+names, byte counts, timing, and outcomes. If you touch what goes into a `TelemetryEvent`, add a
+test asserting the new field can't carry user data, and say so in the PR description.
+
 ## Before opening a PR
 
 ```bash
-pnpm build   # from typescript/
+cd typescript
+pnpm build
 pnpm test
 ```
 
-Both must pass. Update the relevant package's README if you changed its public API, and update
-`examples/hello-world` if the change affects how a basic server is written.
+Both must pass; CI runs exactly these on Node 20.19, 22.12, and 24. Also:
+
+- Update the relevant package's README if you changed its public API.
+- Update `examples/hello-world` if the change affects how a basic server is written.
+- Use a descriptive commit message. The history uses Conventional Commits
+  (`fix:`, `feat:`, `docs:`, `test:`, `ci:`) — please match it.
 
 ## Reporting bugs / requesting features
 
 Open an issue with a minimal reproduction where possible. For MCP protocol questions unrelated
 to mcpfy itself, the [Model Context Protocol spec](https://modelcontextprotocol.io) and the
 official [`@modelcontextprotocol/sdk`](https://github.com/modelcontextprotocol/typescript-sdk)
-are the source of truth — mcpfy is a thin wrapper around it, not a reimplementation.
+are the source of truth.
 
 ## Code of conduct
 
-Be respectful and constructive. This is a small project run in the open — treat it, and the
-people contributing to it, accordingly.
+By participating, you agree to uphold our [Code of Conduct](./CODE_OF_CONDUCT.md). This is a
+small project run in the open — treat it, and the people contributing to it, accordingly.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,33 @@ console.log(await session.callTool("hello"));
 ---
 
 
+## Repository structure
+
+mcpfy is a monorepo. Everything TypeScript lives under [`typescript/`](./typescript), a pnpm
+workspace:
+
+```text
+typescript/
+├── packages/
+│   ├── mcpfy/               # the SDK, published as `mcpfy-sdk`
+│   ├── create-mcpfy-app/    # the `npx create-mcpfy-app` scaffolder
+│   └── mcpfy-pulse/         # opt-in telemetry for MCP servers
+└── examples/
+    ├── hello-world/         # one tool, one prompt, one resource
+    └── widget-hello-world/  # one widget, registered for all three widget protocols
+```
+
+| Package | npm | What it does |
+| --- | --- | --- |
+| [`packages/mcpfy`](./typescript/packages/mcpfy) | [`mcpfy-sdk`](https://www.npmjs.com/package/mcpfy-sdk) | Build and consume MCP servers — tools, prompts, resources, widgets, stdio/HTTP transports, and OAuth. |
+| [`packages/create-mcpfy-app`](./typescript/packages/create-mcpfy-app) | [`create-mcpfy-app`](https://www.npmjs.com/package/create-mcpfy-app) | Scaffolds a working server in one command. |
+| [`packages/mcpfy-pulse`](./typescript/packages/mcpfy-pulse) | [`mcpfy-pulse`](https://www.npmjs.com/package/mcpfy-pulse) | Captures method, size, timing, and outcome metrics. Never sends argument values or resource content. |
+
+`mcpfy-sdk` depends on `mcpfy-pulse`, so build the workspace with `pnpm build` from
+`typescript/` rather than building a single package on its own.
+
+---
+
 ## Documentation
 
 - 📖 **TypeScript SDK Guide**  


### PR DESCRIPTION
## What this changes

Documentation only — no source, build, or test changes.

### `CONTRIBUTING.md` contradicted the codebase

It currently tells contributors:

> especially anything that would pull mcpfy toward mcpfy's larger feature set (Apps/widgets, OAuth, telemetry, etc.) — those are deliberately out of scope for now.

mcpfy ships all three today:

- widgets — `typescript/packages/mcpfy/src/server/widgets/`
- OAuth — `typescript/packages/mcpfy/src/server/auth/` and `src/auth/`
- telemetry — the `mcpfy-pulse` package

The phrase *"pull mcpfy toward mcpfy's larger feature set"* also reads like a find-and-replace artifact from another project. As written, a new contributor could talk themselves out of perfectly valid work.

I rewrote the section to keep what looks like the actual intent — stay small, stay close to the official SDK, discuss new public API surface before a large PR — without the false scope claim. **Please sanity-check that this reflects your current thinking**; I inferred it from the code rather than being told.

### `CONTRIBUTING.md` linked to an anchor that doesn't exist

It pointed at `README.md#repository-structure`. There was no such section. Added one to the root README: a directory tree, a table of the three published packages with npm links, and a note that `mcpfy-sdk` depends on `mcpfy-pulse` so the workspace should be built as a whole. `mcpfy-pulse` was previously not mentioned in the root README at all.

### Also added

- Per-package build/test commands, how to run the scaffolder from source, and how to run an example against a local build.
- A note that changing what a `TelemetryEvent` carries needs a test proving the new field can't carry user data — that promise is the reason anyone installs `mcpfy-pulse`.
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1). `CONTRIBUTING.md` already had a "Code of conduct" heading with no document behind it.
- Issue forms for bugs and features (asking for package, version, transport, Node version, and a reproduction up front) and a PR template.

## How it was verified

- Every command documented was actually run first, including `pnpm --filter create-mcpfy-app dev -- <dir> --no-install`, which scaffolded a working project.
- All three npm links return 200 from the registry.
- Every relative link in `README.md`, `CONTRIBUTING.md`, and `CODE_OF_CONDUCT.md` resolves to a real path.
- All issue-form YAML parses, and the `#repository-structure` anchor now matches a real README heading.

## Notes for the maintainers

- ⚠️ **Merge order:** the rewritten `CONTRIBUTING.md` says CI runs `pnpm build` / `pnpm test` on Node 20.19, 22.12, and 24. That's only true once the companion CI change lands. That branch can't be pushed from here yet (an OAuth `workflow` scope issue on my side, being sorted) — I'll link it as soon as it's up. Either merge this second, or I can drop that sentence if you'd rather take this one standalone.
- The Code of Conduct directs reports to "the maintainers" rather than a specific address — I didn't want to invent an email. Worth filling in with one you own.
- Happy to split this into separate docs / community-files PRs if that's easier to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)