### PR TITLE
docs: document useHostProtocol in the widget hooks table

### DIFF
--- a/typescript/packages/mcpfy/README.md
+++ b/typescript/packages/mcpfy/README.md
@@ -292,6 +292,7 @@ Set `MCPFY_URL` (or `MCP_URL`) to your public MCP origin (for example `https://y
 | `useOpenExternal` | Open a URL via the host |
 | `useLayoutMode` | `{ mode, request, available }` for inline / pip / fullscreen |
 | `useHostContext` | Protocol, layout, locale, platform, `capabilities` (gate follow-up / links / view tools) |
+| `useHostProtocol` | Just the protocol (`"apps-sdk" \| "mcp-apps" \| "mcp-ui" \| "none"`) — same value as `useHostContext().protocol`, without the rest of the context |
 | `useHostTheme` | light / dark |
 | `HostImage` | Image tag with host-safe defaults |
 | `useWidgetState` | Persist JSON on ChatGPT (`widgetState`) |


### PR DESCRIPTION
## What

Adds `useHostProtocol` to the widget hooks table in `typescript/packages/mcpfy/README.md`.

## Why

`useHostProtocol` is a public export of `mcpfy-sdk/widget` (`src/widget-react/index.ts`), and the scaffold templates already point at it in their "also available from `mcpfy-sdk/widget` (not used here)" comment:

```
// useHostProtocol() — same protocol as useHostContext().protocol
```

But it was the one exported hook missing from the README's hook table, so anyone reading the docs rather than the generated template wouldn't find it.

I hit this while learning the SDK — the template comment mentioned the hook, and looking it up in the README turned up nothing.

## Notes

- Docs only, one line, no API change.
- Return type verified against `HostProtocol` in `src/client-widget/index.ts`: `"apps-sdk" | "mcp-apps" | "mcp-ui" | "none"`.
- `pnpm build` and `pnpm test` both pass from `typescript/` (46 tests).